### PR TITLE
fix: Made openssl-sys crate a dependency only on unix targets

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,6 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
-openssl-sys = { version = "0.9", features = ["vendored"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_derive = "1.0.219"
@@ -41,8 +40,11 @@ reqwest = { version = "0.12.15", features = ["json", "blocking"] }
 chrono = { version = "0.4.41", features = ["serde"] }
 tauri-plugin-log = "2"
 log = "0.4"
-
 git2 = { version = "0.18" }
 md5 = "0.8"
 url = { version = "2", features = ["serde"] }
 regex = { version = "1", features = ["unicode"] }
+
+[target.'cfg(unix)'.dependencies]
+openssl-sys = { version = "0.9", features = ["vendored"] }
+


### PR DESCRIPTION
## Changes

`openssl-sys` crate (in vendored mode) was added explicitly in a previous PR to fix the packaging of macOS builds but this now causes (some) Windows builds to stall out and ultimately not compile. This crate is now marked as only needed for the "unix" target family.  