### PR TITLE
fix: GitLab URL verification regex is now valid

### DIFF
--- a/src-tauri/src/contributor.rs
+++ b/src-tauri/src/contributor.rs
@@ -34,7 +34,7 @@ pub async fn get_contributor_info(
 
     let repo = match Repository::open(canonical_path) {
         Ok(repo) => {
-            log::info!("Successfully opened repository at {}", path);
+            log::info!("Successfully opened repository at {path}");
             repo
         }
         Err(e) => {
@@ -58,8 +58,8 @@ pub async fn get_contributor_info(
         Some(target) => {
             // Ensure the branch exists before proceeding
             if !branches.contains(&target.to_string()) {
-                log::error!("Branch: {} not found in the repository.", target);
-                return Err(format!("Branch: {} not found in the repository.", target));
+                log::error!("Branch: {target} not found in the repository.");
+                return Err(format!("Branch: {target} not found in the repository."));
             }
             repo.find_branch(target, BranchType::Local)
                 .map_err(|e| e.to_string())?
@@ -96,10 +96,7 @@ pub async fn get_contributor_info(
         let email = author_signature.email().unwrap_or("").to_string();
         let gravatar_hash = md5::compute(email.clone().trim().to_lowercase());
         let gravatar_login = author_signature.name().unwrap_or("Unknown").to_string();
-        let gravatar_url = format!(
-            "https://www.gravatar.com/avatar/{:x}?d=identicon",
-            gravatar_hash
-        );
+        let gravatar_url = format!("https://www.gravatar.com/avatar/{gravatar_hash:x}?d=identicon");
 
         let commit_tree = commit.tree().map_err(|e| e.to_string())?;
         let parent_tree = if commit.parent_count() > 0 {

--- a/src-tauri/src/repositories.rs
+++ b/src-tauri/src/repositories.rs
@@ -1,7 +1,7 @@
 use git2::{build::RepoBuilder, RemoteCallbacks};
 
 fn clone_progress(cur_progress: usize, total_progress: usize) {
-    println!("\rProgress: {}/{}", cur_progress, total_progress);
+    println!("\rProgress: {cur_progress}/{total_progress}");
 }
 
 #[tauri::command]
@@ -13,11 +13,11 @@ pub fn is_repo_cloned(path: &str) -> bool {
 pub async fn bare_clone(url: &str, path: &str) -> Result<(), String> {
     // Check if path is a valid directory
     if is_repo_cloned(path) {
-        log::info!("Repository already exists at: {}", path);
+        log::info!("Repository already exists at: {path}");
         return Ok(()); // Repository is already cloned, no need to clone again
     }
 
-    log::info!("Cloning repository from {} to {}", url, path);
+    log::info!("Cloning repository from {url} to {path}");
 
     let mut callbacks = RemoteCallbacks::new();
     callbacks.transfer_progress(|progress| {
@@ -34,6 +34,6 @@ pub async fn bare_clone(url: &str, path: &str) -> Result<(), String> {
         .clone(url, std::path::Path::new(path))
         .map_err(|e| e.to_string())?;
 
-    log::info!("Repository cloned successfully at: {}", path);
+    log::info!("Repository cloned successfully at: {path}");
     Ok(())
 }


### PR DESCRIPTION
## Changes

The regex used to ensure name paths for gitlab.com repositories incorrectly ordered a capture class to put a hyphen ('-') between a period ('.') and a plus ('+') which indicated a character range match instead of looking for a match for any of the characters individually. Moved the hyphen to be the last character to avoid this.

Formatted rust code according to clippy's suggestions.