### PR TITLE
fix: pre-commit hook indicates correct linting npm script for rust code

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -67,7 +67,7 @@ if [[ $? -eq 101 ]]; then
     printf "\nLint errors/warnings found in rust code.\n"
 
     printf "
-Run \`npm run rs-lint\` to see lint suggestions or use \`npm run rs-lint:fix\` to
+Run \`npm run clippy\` to see lint suggestions or use \`npm run clippy:fix\` to
 apply lint suggestions to rust crate automatically.
 
 "


### PR DESCRIPTION
# Changes

Hook mentions the old npm script 'rs-lint' and 'rs-lint:fix' which has been migrated to the names 'clippy' and 'clippy:fix' because it uses cargo's clippy subcommand.