### PR TITLE
fix: Changed heading to be repository name

### DIFF
--- a/src/routes/overview-page/+page.svelte
+++ b/src/routes/overview-page/+page.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <div class="main">
-    <Heading repo_path={repo_path.split("/").pop() || repo_path} {repo_type} />
+    <Heading repo_path={repo_path.split("/")[1] || repo_path} {repo_type} />
     <CommitGraph {contributors} {branches} />
     <div class="bottom-container">
         <ButtonPrimaryMedium icon="table-import" label="Upload Marking Sheet" />


### PR DESCRIPTION
 - Changed heading of the overview page to be the repository properly by using the second url path rather than the last