### PR TITLE
Fixed bug where heading did not span full window width

### DIFF
--- a/src/lib/components/overview-page/Banner.svelte
+++ b/src/lib/components/overview-page/Banner.svelte
@@ -60,7 +60,7 @@ contains the user's name and profile image.
         display: flex;
         justify-content: space-between;
         gap: 2rem;
-        min-width: 0;
+        width: (100hw - 4rem);
     }
 
     .left-menu-container {

--- a/src/lib/components/overview-page/CommitGraph.svelte
+++ b/src/lib/components/overview-page/CommitGraph.svelte
@@ -35,7 +35,7 @@
 
 <style>
     .container {
-        padding: 2rem;
+        padding: 0rem 2rem;
         display: flex;
         flex-direction: column;
         align-items: center;

--- a/src/lib/components/overview-page/ContributorCards.svelte
+++ b/src/lib/components/overview-page/ContributorCards.svelte
@@ -72,6 +72,6 @@
         flex-wrap: wrap;
         gap: 1rem;
         justify-content: center;
-        margin-top: 100px; /* Increased to prevent overlap with expanded graph x-axis */
+        margin-top: 80px; /* Increased to prevent overlap with expanded graph x-axis */
     }
 </style>

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -629,6 +629,6 @@
     .chart-container {
         width: 100%;
         font-family: "DM Sans", sans-serif;
-        padding-bottom: 2rem;
+        padding-bottom: 0rem;
     }
 </style>


### PR DESCRIPTION
The heading now spans the full window width. The spacing of components on the overview page is now adjusted to remove oversized gaps between elements.