### PR TITLE
hotfix: Add await to manifest store updates

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -195,11 +195,10 @@
             );
 
             if (!repo_exists) {
-                manifest.create_repository(repository_information, url_trimmed);
+               await manifest.create_repository(repository_information, url_trimmed);
             }
 
-            manifest.update_repository_timestamp(repo_url_input);
-
+            await manifest.update_repository_timestamp(repo_url_input);
             await invoke("save_manifest", { manifest: $manifest });
 
             // Navigate to the overview page


### PR DESCRIPTION
# 🔥 Hotfix PR Template

## 📌 Summary

Ensures that the manifest store is updated before being sent to the backend to be saved to disk

## 🔍 Changes Made

- Added ```await``` before calling manifest ```create_repository``` and ```update_repository_timestamp``` in routes/+page.svelte

## ✅ Acceptance Criteria

- [x] Repositories are added to manifest file when loaded initially
- [x] Timestamp of last accessed time is updated correctly

## 🔗 Related Notion Tasks

- [Fix bug relating to bookmarking functionality](https://www.notion.so/Fix-bug-relating-to-bookmarking-functionality-26bd2a7cea4a80b58d18ce42801996f9?source=copy_link)

