### PR TITLE
feat: Implement Local Storage for Repository Persistence and UI Fixes

### DIFF
--- a/src/lib/components/overview-page/Banner.svelte
+++ b/src/lib/components/overview-page/Banner.svelte
@@ -4,13 +4,15 @@
     import UserMenu from "$lib/components/overview-page/UserMenu.svelte";
 
     let {
+        owner,
+        repo,
         repo_url,
-        repo_path,
         username = "Baaset Moslih",
         profile_image_url = "/mock_profile_img.png",
     }: {
+        owner?: string;
+        repo?: string;
         repo_url?: string;
-        repo_path?: string;
         username?: string;
         profile_image_url?: string;
     } = $props();
@@ -42,8 +44,8 @@ contains the user's name and profile image.
 
 <div class="header">
     <div class="left-menu-container">
-        {#if repo_url && repo_path}
-            <LeftMenuWithRepo {repo_url} {repo_path} />
+        {#if repo_url && owner && repo}
+            <LeftMenuWithRepo {repo_url} {owner} {repo} />
         {:else}
             <LeftMenu />
         {/if}

--- a/src/lib/components/overview-page/Heading.svelte
+++ b/src/lib/components/overview-page/Heading.svelte
@@ -12,7 +12,7 @@
 
     let {
         repo: repo,
-        repo_type: repo_type = "github",
+        source_type: source_type = 0,
         repo_url,
         branches = [],
         branch_selection = $bindable(),
@@ -21,6 +21,7 @@
         contributors = $bindable<Contributor[]>([]),
     } = $props();
 
+    let source_name = source_type === 0 ? "github" : source_type === 1 ? "gitlab" : "folder-code";
     let show_modal = $state(false);
 
     let file_input: HTMLInputElement;
@@ -97,7 +98,7 @@
             <span class="repo-path display-title" title={repo}>{repo}</span>
             <div class="repo-icon">
                 <Icon
-                    icon={`tabler:brand-${repo_type}`}
+                    icon={`tabler:brand-${source_name}`}
                     class="icon-xlarge"
                     style="color: white"
                 />

--- a/src/lib/components/overview-page/LeftMenuWithRepo.svelte
+++ b/src/lib/components/overview-page/LeftMenuWithRepo.svelte
@@ -6,10 +6,12 @@
 
     let {
         repo_url,
-        repo_path,
+        owner,
+        repo,
     }: {
         repo_url: string;
-        repo_path: string;
+        owner: string;
+        repo: string;
     } = $props();
 
     let bookmarked = $state(
@@ -48,7 +50,7 @@ toggle button.
     {#snippet content()}
         <!-- repo pathway display -->
         <div class="repo-pathway">
-            {repo_path}
+            {owner}/{repo}
         </div>
 
         <!-- bookmark toggle -->

--- a/src/lib/components/overview-page/LeftMenuWithRepo.svelte
+++ b/src/lib/components/overview-page/LeftMenuWithRepo.svelte
@@ -3,6 +3,7 @@
     import LeftMenu from "./LeftMenu.svelte";
     import { manifest } from "$lib/stores/manifest";
     import { invoke } from "@tauri-apps/api/core";
+    import { onMount } from "svelte";
 
     let {
         repo_url,
@@ -26,8 +27,14 @@
             manifest.unbookmark(repo_url);
         }
         invoke("save_manifest", { manifest: $manifest });
-    }
-</script>
+        }
+        
+    // Update bookmarked state whenever manifest changes
+    $effect(() => {
+    bookmarked = $manifest.repository.some((r) => r.url === repo_url && r.bookmarked);
+    });
+        
+    </script>
 
 <!--
 @component

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -27,11 +27,7 @@ export type UserDisplayData = Readonly<{
 }>;
 
 // Load branches for a repository
-export async function load_branches(repo: string): Promise<string[]> {
-    const working_dir = await invoke<string>("get_working_directory");
-    const repo_path = `${working_dir}/repositories/${repo}`;
-    console.log("PATH", repo_path);
-
+export async function load_branches(repo_path: string): Promise<string[]> {
     try {
         const real_branches = await invoke<string[]>("get_branch_names", {
             path: repo_path,
@@ -49,18 +45,13 @@ type DateRange = {
     end: number;
 };
 
-export async function load_commit_data(
-    source: string,
+export async function bare_clone(
+    source: string, 
     owner: string,
     repo: string,
-    source_type: 0 | 1 | 2,
-    branch?: string,
-    start_date?: string,
-    end_date?: string
-): Promise<Contributor[]> {
-    info(`Loading contributor data for ${owner}/${repo}...`);
+    source_type: 0 | 1 | 2
+): Promise<string> {
     const repo_url = `${source}/${owner}/${repo}`;
-
     const working_dir = await invoke<string>("get_working_directory");
     const repo_path = `${working_dir}/repositories/${source_type}-${owner}-${repo}`;
     try {
@@ -68,7 +59,7 @@ export async function load_commit_data(
             url: repo_url,
             path: repo_path,
         });
-        info(`Repository is cloned or already exists at ${repo_path}`);
+        return repo_path;
     } catch (err) {
         const error_message = String(err);
         info(`Failed to clone the repository: ${error_message}`);
@@ -78,9 +69,17 @@ export async function load_commit_data(
             show_token_modal(error_message, repo_url, repo_path);
         }
 
-        return [];
+        return repo_path;
     }
+}
 
+export async function load_commit_data(
+    repo_path: string,
+    branch?: string,
+    start_date?: string,
+    end_date?: string
+): Promise<Contributor[]> {
+    info(`Loading contributor data for ${repo_path}...`);
     try {
         let date_range: DateRange | undefined = undefined;
 

--- a/src/lib/stores/manifest.ts
+++ b/src/lib/stores/manifest.ts
@@ -138,7 +138,7 @@ function create_manifest_store() {
             const new_repo: RepoSchema = {
                 name: backendResult.repo,
                 url: repo_url,
-                path: `${working_dir}/gitguage/repositories/${repo_url.split("/")[3]}-${repo_url.split("/")[4]}`,
+                path: `${working_dir}/repositories/${repo_url.split("/")[3]}-${repo_url.split("/")[4]}`,
                 bookmarked: false,
                 cloned: true,
                 email_mapping: null,

--- a/src/lib/stores/manifest.ts
+++ b/src/lib/stores/manifest.ts
@@ -12,6 +12,8 @@ export interface RepoSchema {
     grading_sheet: string | null;
     last_accessed: string;
     name: string;
+    owner: string;
+    source_type: 0 | 1 | 2; // 0 = GitHub, 1 = GitLab, 2 = Local
     path: string;
     url: string;
 }
@@ -20,7 +22,7 @@ export interface ManifestSchema {
     repository: RepoSchema[];
 }
 
-interface RepositoryInformation {
+export interface RepositoryInformation {
     owner: string;
     repo: string;
     source_type: 0 | 1 | 2;
@@ -139,6 +141,8 @@ function create_manifest_store() {
 
             const new_repo: RepoSchema = {
                 name: repo_info.repo,
+                owner: repo_info.owner,
+                source_type: repo_info.source_type,
                 url: repo_url,
                 path: repo_path,
                 bookmarked: false,

--- a/src/lib/stores/manifest.ts
+++ b/src/lib/stores/manifest.ts
@@ -20,7 +20,7 @@ export interface ManifestSchema {
     repository: RepoSchema[];
 }
 
-interface BackendVerificationResult {
+interface RepositoryInformation {
     owner: string;
     repo: string;
     source_type: 0 | 1 | 2;
@@ -130,17 +130,19 @@ function create_manifest_store() {
 
         /** Create a new repository inside of the manifest file */
         async create_repository(
-            backendResult: BackendVerificationResult,
-            repo_url: string
+            repo_info: RepositoryInformation,
+            repo_url: string,
+            is_local: boolean = false
         ) {
             const working_dir = await invoke<string>("get_working_directory");
+            const repo_path = (is_local) ? repo_url : `${working_dir}/repositories/${repo_info.source_type}-${repo_info.owner}-${repo_info.repo}`;
 
             const new_repo: RepoSchema = {
-                name: backendResult.repo,
+                name: repo_info.repo,
                 url: repo_url,
-                path: `${working_dir}/repositories/${repo_url.split("/")[3]}-${repo_url.split("/")[4]}`,
+                path: repo_path,
                 bookmarked: false,
-                cloned: true,
+                cloned: !is_local,
                 email_mapping: null,
                 grading_sheet: null,
                 last_accessed: new Date().toISOString(),

--- a/src/lib/utils/localstorage.ts
+++ b/src/lib/utils/localstorage.ts
@@ -1,0 +1,50 @@
+import { browser } from "$app/environment";
+import type { Contributor } from "$lib/metrics";
+let STORAGE_KEY = "page_state"
+export function load_state(s: any) {
+    if (browser) {
+        try {
+            const saved = localStorage.getItem(STORAGE_KEY);
+            if (saved) {
+                const parsed = JSON.parse(saved);
+                Object.assign(s, parsed);  // Merge into page.state
+            }
+        } catch (error) {
+            console.error("Failed to load page state from storage:", error);
+        }
+    }
+}
+
+// Function to save state to localStorage
+export async function save_state(s: any) {
+    if (browser) {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+        } catch (error) {
+            console.error("Failed to save page state to storage:", error);
+        }
+    }
+}
+
+import type { RepositoryInformation } from "$lib/stores/manifest";
+
+export async function generate_state_object(
+    working_dir: string,
+    repository_information: RepositoryInformation,
+    repo_url: string,
+    source_type: 0 | 1 | 2,
+    branches: string[],
+    contributors: Contributor[],
+    selected_branch: string = ""
+) {
+    return {
+        repo_path: `${working_dir}/repositories/${source_type}-${repository_information.owner}-${repository_information.repo}`,
+        repo_url: repo_url,
+        owner: repository_information.owner,
+        repo: repository_information.repo,
+        source_type: source_type,
+        selected_branch: selected_branch,
+        branches: branches,
+        contributors: contributors,
+    };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -195,11 +195,10 @@
             );
 
             if (!repo_exists) {
-                manifest.create_repository(repository_information, url_trimmed);
+               await manifest.create_repository(repository_information, url_trimmed);
             }
 
-            manifest.update_repository_timestamp(repo_url_input);
-
+            await manifest.update_repository_timestamp(repo_url_input);
             await invoke("save_manifest", { manifest: $manifest });
 
             // Navigate to the overview page

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -65,12 +65,6 @@
     let verification_error: boolean = $state(false);
     let waiting_for_auth: boolean = $state(false);
 
-    interface BackendVerificationResult {
-        owner: string;
-        repo: string;
-        source_type: 0 | 1 | 2;
-    }
-
     async function select_bookmarked_repo(repo_url: string) {
         repo_url_input = repo_url;
         await handle_verification();

--- a/src/routes/overview-page/+layout.svelte
+++ b/src/routes/overview-page/+layout.svelte
@@ -11,6 +11,7 @@
     import { page } from "$app/state";
     import Banner from "$lib/components/overview-page/Banner.svelte";
     import Sidebar from "$lib/components/global/Sidebar.svelte";
+    import { load_state } from "$lib/utils/localstorage";
 
     let profile_image_url = "/mock_profile_img.png";
     let username = "Baaset Moslih";
@@ -18,13 +19,16 @@
     let { children } = $props();
 
     const s = page.state as any;
+    load_state(s);
+    console.log(`Repo URL: ${s.repo_url}`);
+    let owner = $derived(s.owner);
+    let repo = $derived(s.repo);
     let repo_url = $derived(s.repo_url);
-    let repo_path = $derived(s.repo_path);
 </script>
 
 <main class="page">
     <header class="header">
-        <Banner {repo_url} {repo_path} {username} {profile_image_url} />
+        <Banner {repo} {owner} {repo_url} {username} {profile_image_url} />
     </header>
     {@render children()}
 </main>

--- a/src/routes/overview-page/+page.svelte
+++ b/src/routes/overview-page/+page.svelte
@@ -12,24 +12,23 @@
     import { download_populated_file } from "$lib/utils/grading";
     import { load_branches, load_commit_data } from "$lib/metrics";
     import { invoke } from "@tauri-apps/api/core";
-    import { manifest, type Config } from "$lib/stores/manifest";
+    import { manifest, type Config, type ManifestSchema } from "$lib/stores/manifest";
     import type { Contributor } from "$lib/metrics";
     import { onMount } from "svelte";
-
+    import { load_state } from "$lib/utils/localstorage";
+    
     const s = page.state as any;
-    let owner = $state(s.owner || "");
+    load_state(s);
     let repo = $state(s.repo || "");
-    let repo_type = $state(s.repo_type);
     let repo_path = $state(s.repo_path || "");
+    let source_type : 0 | 1 | 2 = $state(s.source_type || 0); // 0 = GitHub, 1 = GitLab, 2 = Local
+    let repo_url = $state(s.repo_url || "");
+
     let branches = $state(s.branches || []);
     let contributors = $state(s.contributors || []);
-
-    let branch_selection = $state("");
-    let start_date = $state("");
-    let end_date = $state("");
-
-    let source_type = $state(s.source_type);
-    let repo_url = $state(s.repo_url || "");
+    let branch_selection = $state(s.branch_selection || "");
+    let start_date = $state(s.start_date || "");
+    let end_date = $state(s.end_date || "");
     let email_mapping: Config | null = $derived(
         $manifest.repository.filter((r) => r.url === repo_url)[0]
             ?.email_mapping || null
@@ -50,22 +49,6 @@
         selected_view = id;
         console.log(selected_view);
     }
-
-    onMount(async () => {
-        if (email_mapping) {
-            try {
-                contributors = await invoke<Contributor[]>(
-                    "group_contributors_by_config",
-                    {
-                        config_json: email_mapping,
-                        contributors: contributors,
-                    }
-                );
-            } catch (error) {
-                console.error("Error applying config:", error);
-            }
-        }
-    });
 
     let show_modal = $state(false);
     const open_modal = () => (show_modal = true);
@@ -110,49 +93,50 @@
         void info("[download] populated file saved");
     }
 
+    async function load_graph() {
+        const branch_arg =
+            branch_selection === "" ? undefined : branch_selection;
+        console.log("Loading graph with:", {
+            repo_path,
+            branch_arg,
+            start_date,
+            end_date,
+        });
+        let new_contributors = await load_commit_data(
+            repo_path,
+            branch_arg,
+            start_date,
+            end_date
+        );
+
+        // Apply config grouping if email_mapping is present
+        if (email_mapping) {
+            try {
+                new_contributors = await invoke<Contributor[]>(
+                    "group_contributors_by_config",
+                    {
+                        config_json: email_mapping,
+                        contributors: new_contributors,
+                    }
+                );
+            } catch (error) {
+                console.error(
+                    "Error applying config after branch change:",
+                    error
+                );
+            }
+        }
+        contributors = [...new_contributors];
+    }
+
     $effect(() => {
         if (
             (branch_selection && branch_selection !== "") ||
             (start_date && end_date)
         ) {
-            // Fetch new contributors for the selected branch
             (async () => {
-                const source =
-                    source_type === 0
-                        ? "https://github.com"
-                        : source_type === 1
-                          ? "https://gitlab.com"
-                          : "";
-                const branch_arg =
-                    branch_selection === "" ? undefined : branch_selection;
-                let new_contributors = await load_commit_data(
-                    source,
-                    owner,
-                    repo,
-                    repo_type,
-                    branch_arg,
-                    start_date,
-                    end_date
-                );
-
-                // Apply config grouping if email_mapping is present
-                if (email_mapping) {
-                    try {
-                        new_contributors = await invoke<Contributor[]>(
-                            "group_contributors_by_config",
-                            {
-                                config_json: email_mapping,
-                                contributors: new_contributors,
-                            }
-                        );
-                    } catch (error) {
-                        console.error(
-                            "Error applying config after branch change:",
-                            error
-                        );
-                    }
-                }
-                contributors = [...new_contributors];
+                // Fetch new contributors for the selected branch
+                await load_graph();
             })();
         }
     });
@@ -165,12 +149,39 @@
             })();
         }
     });
+
+    onMount(async () => {
+        try {
+            let data = await invoke<ManifestSchema>("read_manifest");
+            manifest.set(data);
+            console.log("page", data);
+        } catch (e: any) {
+            let err = typeof e === "string" ? e : (e?.message ?? String(e));
+            console.error("read_manifest failed", e);
+        }
+        if (email_mapping) {
+            try {
+                contributors = await invoke<Contributor[]>(
+                    "group_contributors_by_config",
+                    {
+                        config_json: email_mapping,
+                        contributors: contributors,
+                    }
+                );
+            } catch (error) {
+                console.error("Error applying config:", error);
+            }
+        }
+        if (branches.length === 0 || contributors.length === 0) {
+            await load_graph();
+        }
+    });
 </script>
 
 <div class="page">
     <Heading
         {repo}
-        {repo_type}
+        {source_type}
         {repo_url}
         {branches}
         bind:branch_selection


### PR DESCRIPTION
# 🚀 Feature PR Template

## 📌 Summary

This feature introduces local storage integration to persist repository information, enhancing user experience by remembering repository settings across sessions. It includes separating the cloning and commit data loading processes, schema updates for better data tracking, and various fixes to improve UI consistency and functionality, particularly around bookmarks and repository identification.

## 🔍 Changes Made

- **New functionality implemented**
  - A `localStorage` utility has been created for persistent data storage.
  - The application now supports manifest storage for local repositories.
  - Repository cloning and commit data loading have been refactored into separate, more maintainable processes.

- **Schema and State Management**
  - The repository schema was updated to include `owner` and `source_type` for better data categorization.
  - State management for bookmarks has been improved to reflect manifest changes accurately.

- **Bug Fixes**
  - Resolved an issue with opening repositories from bookmarks in the sidebar.
  - Corrected the display of banner text elements by populating them from `localStorage`.
  - Fixed repository paths within the manifest file.
  - Ensured asynchronous operations on the manifest store are properly awaited.

- **UI Enhancements**
  - Re-added distinct icons for GitHub, GitLab, and local repositories in the side menu.

## ✅ Acceptance Criteria

- [ ] Feature performs as expected in all supported environments.
- [ ] Local repository information is successfully persisted and reloaded across browser sessions.
- [ ] Icons for GitHub, GitLab, and local repositories are displayed correctly.
- [ ] Bookmarked repositories, open and function as expected.

## 🔗 Related Notion Tasks
- [Implement Local Storage for Repository Persistence and UI Fixes](https://www.notion.so/Implement-Local-Storage-for-Repository-Persistence-and-UI-Fixes-26cd2a7cea4a80f891b5f12939b81679?source=copy_link)