### PR TITLE
feat: Add support for local repositories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitgauge",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitgauge",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ pub fn run() {
             repositories::bare_clone,
             repositories::try_clone_with_token,
             repositories::is_repo_cloned,
+            repositories::get_local_repo_information,
             url_verifier::verify_and_extract_source_info,
             manifest::read_manifest,
             manifest::save_manifest,

--- a/src-tauri/src/manifest.rs
+++ b/src-tauri/src/manifest.rs
@@ -78,18 +78,27 @@ pub async fn check_manifest() -> Result<(), String> {
 
     if let Some(repos) = manifest.get("repository").and_then(|r| r.as_array()) {
         for repo in repos {
-            if check_repository(repo).await.is_err() {
-                manifest_changed = true;
-                if let Some(path_str) = repo.get("path").and_then(|p| p.as_str()) {
-                    let repo_path = PathBuf::from(path_str);
-                    if repo_path.is_dir() {
-                        if let Err(e) = std::fs::remove_dir_all(&repo_path) {
-                            eprintln!("Failed to delete repository directory {path_str}: {e}");
+            match check_repository(repo).await {
+                Ok(()) => {
+                    // Repository should stay in manifest
+                    updated_repos.push(repo.clone());
+                }
+                Err(should_delete_directory) => {
+                    // Repository should be removed from manifest
+                    manifest_changed = true;
+                    
+                    // Delete directory only if cloned=true and >30 days
+                    if should_delete_directory {
+                        if let Some(path_str) = repo.get("path").and_then(|p| p.as_str()) {
+                            let repo_path = PathBuf::from(path_str);
+                            if repo_path.is_dir() {
+                                if let Err(e) = std::fs::remove_dir_all(&repo_path) {
+                                    eprintln!("Failed to delete repository directory {path_str}: {e}");
+                                }
+                            }
                         }
                     }
                 }
-            } else {
-                updated_repos.push(repo.clone());
             }
         }
     }
@@ -108,22 +117,44 @@ pub async fn check_manifest() -> Result<(), String> {
 }
 
 async fn check_repository(repo: &serde_json::Value) -> Result<(), bool> {
-    // Repositories which are not Bookmarked stay cloned for 30 days
+    // If repository is bookmarked, it always stays in the manifest
+    if let Some(bookmarked) = repo.get("bookmarked").and_then(|b| b.as_bool()) {
+        if bookmarked {
+            return Ok(());
+        }
+    }
+    
+    // Check if the repository has been accessed within 30 days
     if let Some(last_accessed) = repo.get("last_accessed").and_then(|l| l.as_str()) {
-        if let Ok(last_accessed_time) = chrono::DateTime::parse_from_rfc3339(last_accessed) {
-            let now = chrono::Utc::now();
-            if now.signed_duration_since(last_accessed_time).num_days() < 30
-                && repo
-                    .get("cloned")
-                    .and_then(|c| c.as_bool())
-                    .unwrap_or(false)
-            {
-                return Ok(());
+        match chrono::DateTime::parse_from_rfc3339(last_accessed) {
+            Ok(last_accessed_time) => {
+                let now = chrono::Utc::now();
+                log::info!("Last accessed: {last_accessed_time}, Now: {now}");
+                
+                // If accessed within 30 days, keep the repository
+                if now.signed_duration_since(last_accessed_time).num_days() < 30 {
+                    return Ok(());
+                }
+                
+                // If older than 30 days and not bookmarked, determine cleanup action
+                let cloned = repo.get("cloned").and_then(|c| c.as_bool()).unwrap_or(false);
+                
+                // Return Err(true) if directory should be deleted (cloned=true)
+                // Return Err(false) if only manifest entry should be removed (cloned=false)
+                return Err(cloned);
+            },
+            Err(e) => {
+                log::warn!("Failed to parse datetime '{}': {}", last_accessed, e);
+                // For invalid datetime, assume it's old and handle based on cloned status
+                let cloned = repo.get("cloned").and_then(|c| c.as_bool()).unwrap_or(false);
+                return Err(cloned);
             }
         }
     }
-
-    Err(false)
+    
+    // If no last_accessed field, assume it's old and handle based on cloned status
+    let cloned = repo.get("cloned").and_then(|c| c.as_bool()).unwrap_or(false);
+    Err(cloned)
 }
 
 async fn save_manifest_file(manifest: &serde_json::Value) -> Result<(), String> {

--- a/src-tauri/src/repositories.rs
+++ b/src-tauri/src/repositories.rs
@@ -65,20 +65,22 @@ pub fn get_local_repo_information(path: &str) -> Result<String, String> {
         return Err("No repository found".into());
     }
 
-    // Returns the name and owner of the repository if it can be opened    
+    // Returns the name and owner of the repository if it can be opened
 
     match git2::Repository::open(path) {
         Ok(repo) => {
-            if let Some(remote) = repo.find_remote("origin").ok() {
+            if let Ok(remote) = repo.find_remote("origin") {
                 if let Some(url) = remote.url() {
                     return Ok(url.to_string());
                 }
             }
-            return Err(format!("Failed to open repository at {path}: No origin remote found"));
+            Err(format!(
+                "Failed to open repository at {path}: No origin remote found"
+            ))
         }
         Err(e) => {
             log::error!("Failed to open repository at {path}: {e}");
-            return Err(format!("Failed to open repository: {e}"));
+            Err(format!("Failed to open repository: {e}"))
         }
     }
 }

--- a/src/lib/components/global/Sidebar.svelte
+++ b/src/lib/components/global/Sidebar.svelte
@@ -149,7 +149,7 @@
             <h2 class="heading-1 sidebar-item-header white">Bookmarks</h2>
         </div>
 
-        {#each bookmarked_repos as repo (repo.repo_name)}
+        {#each bookmarked_repos as repo (repo.repo_url)}
             {#if repo.repo_bookmarked}
                 <button
                     class="bookmark-item"

--- a/src/lib/stores/manifest.ts
+++ b/src/lib/stores/manifest.ts
@@ -134,12 +134,12 @@ function create_manifest_store() {
         async create_repository(
             repo_info: RepositoryInformation,
             repo_url: string,
-            is_local: boolean = false
+            source_type: 0 | 1 | 2,
+            repo_local_path: string
         ) {
             const working_dir = await invoke<string>("get_working_directory");
-            const repo_path = is_local
-                ? repo_url
-                : `${working_dir}/repositories/${repo_info.source_type}-${repo_info.owner}-${repo_info.repo}`;
+            const repo_path = (source_type === 2) ? repo_local_path : `${working_dir}/repositories/${repo_info.source_type}-${repo_info.owner}-${repo_info.repo}`;
+            repo_url = (source_type === 2) ? repo_local_path : repo_url;
 
             const new_repo: RepoSchema = {
                 name: repo_info.repo,
@@ -148,7 +148,7 @@ function create_manifest_store() {
                 url: repo_url,
                 path: repo_path,
                 bookmarked: false,
-                cloned: !is_local,
+                cloned: source_type !== 2,
                 email_mapping: null,
                 grading_sheet: null,
                 last_accessed: new Date().toISOString(),

--- a/src/lib/stores/manifest.ts
+++ b/src/lib/stores/manifest.ts
@@ -138,8 +138,11 @@ function create_manifest_store() {
             repo_local_path: string
         ) {
             const working_dir = await invoke<string>("get_working_directory");
-            const repo_path = (source_type === 2) ? repo_local_path : `${working_dir}/repositories/${repo_info.source_type}-${repo_info.owner}-${repo_info.repo}`;
-            repo_url = (source_type === 2) ? repo_local_path : repo_url;
+            const repo_path =
+                source_type === 2
+                    ? repo_local_path
+                    : `${working_dir}/repositories/${repo_info.source_type}-${repo_info.owner}-${repo_info.repo}`;
+            repo_url = source_type === 2 ? repo_local_path : repo_url;
 
             const new_repo: RepoSchema = {
                 name: repo_info.repo,

--- a/src/lib/utils/localstorage.ts
+++ b/src/lib/utils/localstorage.ts
@@ -39,7 +39,10 @@ export async function generate_state_object(
     selected_branch: string = ""
 ) {
     return {
-        repo_path: (source_type === 2) ? repo_url : `${working_dir}/repositories/${source_type}-${repository_information.owner}-${repository_information.repo}`,
+        repo_path:
+            source_type === 2
+                ? repo_url
+                : `${working_dir}/repositories/${source_type}-${repository_information.owner}-${repository_information.repo}`,
         repo_url: repo_url,
         owner: repository_information.owner,
         repo: repository_information.repo,

--- a/src/lib/utils/localstorage.ts
+++ b/src/lib/utils/localstorage.ts
@@ -39,7 +39,7 @@ export async function generate_state_object(
     selected_branch: string = ""
 ) {
     return {
-        repo_path: `${working_dir}/repositories/${source_type}-${repository_information.owner}-${repository_information.repo}`,
+        repo_path: (source_type === 2) ? repo_url : `${working_dir}/repositories/${source_type}-${repository_information.owner}-${repository_information.repo}`,
         repo_url: repo_url,
         owner: repository_information.owner,
         repo: repository_information.repo,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -161,6 +161,7 @@
             if (source_type === 2) {
                 let remote_url = await invoke<string>("get_local_repo_information", {path: repo_url_input});
                 repository_information = get_repo_info(remote_url.replace(".git", ""));
+                repository_information.source_type = 2;
             } else {
                 repository_information = get_repo_info(repo_url_input);
             }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -159,8 +159,8 @@
         };
         try {
             if (source_type === 2) {
-                let remote_url = await invoke("get_local_repo_information", {path: repo_url_input});
-                repository_information = get_repo_info(remote_url);
+                let remote_url = await invoke<string>("get_local_repo_information", {path: repo_url_input});
+                repository_information = get_repo_info(remote_url.replace(".git", ""));
             } else {
                 repository_information = get_repo_info(repo_url_input);
             }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -133,8 +133,8 @@
     }
 
     async function local_verification() {
-        await invoke("get_local_repo_information", {path: repo_url_input});
-        console.log("Local repo selected, skipping verification.");
+        await invoke("get_local_repo_information", { path: repo_url_input });
+        info("Local repo selected, skipping verification.");
     }
 
     async function handle_verification() {
@@ -159,8 +159,13 @@
         };
         try {
             if (source_type === 2) {
-                let remote_url = await invoke<string>("get_local_repo_information", {path: repo_url_input});
-                repository_information = get_repo_info(remote_url.replace(".git", ""));
+                let remote_url = await invoke<string>(
+                    "get_local_repo_information",
+                    { path: repo_url_input }
+                );
+                repository_information = get_repo_info(
+                    remote_url.replace(".git", "")
+                );
                 repository_information.source_type = 2;
             } else {
                 repository_information = get_repo_info(repo_url_input);
@@ -185,20 +190,27 @@
 
             let contributors = await load_commit_data(repo_path);
 
-            const url_trimmed = (source_type === 2) ?
-                repo_url_input :
-                repository_information.source +
-                "/" +
-                repository_information.owner +
-                "/" +
-                repository_information.repo;
+            const url_trimmed =
+                source_type === 2
+                    ? repo_url_input
+                    : repository_information.source +
+                      "/" +
+                      repository_information.owner +
+                      "/" +
+                      repository_information.repo;
             // Check if the repository exists in the manifest
             const repo_exists = $manifest["repository"].some(
-                (item) => item.url === url_trimmed && item.source_type === source_type
+                (item) =>
+                    item.url === url_trimmed && item.source_type === source_type
             );
 
             if (!repo_exists) {
-               await manifest.create_repository(repository_information, url_trimmed, source_type, repo_path);
+                await manifest.create_repository(
+                    repository_information,
+                    url_trimmed,
+                    source_type,
+                    repo_path
+                );
             }
 
             await manifest.update_repository_timestamp(url_trimmed);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -133,8 +133,8 @@
     }
 
     async function local_verification() {
-        info("Local verification called");
-        // Implement local verification logic here
+        await invoke("get_local_repo_information", {path: repo_url_input});
+        console.log("Local repo selected, skipping verification.");
     }
 
     async function handle_verification() {
@@ -151,30 +151,41 @@
 
         let source_type = get_source_type(repo_url_input);
 
-        if (source_type === 2) {
-            await local_verification();
-            return;
-        }
-
+        let repository_information: {
+            source_type: 0 | 1 | 2;
+            source: string;
+            owner: string;
+            repo: string;
+        };
         try {
-            const repository_information = get_repo_info(repo_url_input);
+            if (source_type === 2) {
+                let remote_url = await invoke("get_local_repo_information", {path: repo_url_input});
+                repository_information = get_repo_info(remote_url);
+            } else {
+                repository_information = get_repo_info(repo_url_input);
+            }
 
             // Update the repo store with the new URL
-            set_repo_url(repo_url_input);
-
+            let repo_path: string;
+            if (source_type === 2) {
+                repo_path = repo_url_input;
+            } else {
+                set_repo_url(repo_url_input);
+                repo_path = await bare_clone(
+                    repository_information.source,
+                    repository_information.owner,
+                    repository_information.repo,
+                    source_type
+                );
+            }
             // Call loadBranches and loadCommitData and wait for both to complete
-            let repo_path = await bare_clone(
-                repository_information.source,
-                repository_information.owner,
-                repository_information.repo,
-                source_type
-            );
 
             let branches = await load_branches(repo_path);
 
             let contributors = await load_commit_data(repo_path);
 
-            const url_trimmed =
+            const url_trimmed = (source_type === 2) ?
+                repo_url_input :
                 repository_information.source +
                 "/" +
                 repository_information.owner +
@@ -182,14 +193,11 @@
                 repository_information.repo;
             // Check if the repository exists in the manifest
             const repo_exists = $manifest["repository"].some(
-                (item) => item.url === url_trimmed
+                (item) => item.url === url_trimmed && item.source_type === source_type
             );
 
             if (!repo_exists) {
-                await manifest.create_repository(
-                    repository_information,
-                    url_trimmed
-                );
+               await manifest.create_repository(repository_information, url_trimmed, source_type, repo_path);
             }
 
             await manifest.update_repository_timestamp(url_trimmed);


### PR DESCRIPTION
# 🚀 Feature PR Template

## 📌 Summary

This feature introduces support for integrating local Git repositories into the application. It includes backend functionality for retrieving information from local repositories and managing their lifecycle, as well as frontend UI updates to add, verify, and manage these local repositories.

## 🔍 Changes Made

Describe the key changes made in this feature.

- **New functionality implemented**
    - Implemented a function to get information from local git repositories, including extracting remote URLs.
    - Enhanced repository cleanup logic in the manifest, with flexible rules for bookmarked and non-bookmarked repositories.
    - Updated the frontend to support local repository integration, including UI for verification and path handling.
    - Corrected local repository URL handling by removing the `.git` suffix.
    - Changed the key for sidebar bookmarks to `repo_url` to ensure uniqueness.

## 🔗 Related Notion Tasks

- [Local Repository Loading and Manifest Management](https://www.notion.so/Local-Repository-Loading-and-Manifest-Management-26cd2a7cea4a801aa7ade51ba42c485a?source=copy_link)
- [Automatic deletion of cloned repositories](https://www.notion.so/Automatic-deletion-of-cloned-repositories-26cd2a7cea4a80d8ae6cc0a0d4961d34?source=copy_link)