### PR TITLE
feat: Scaling can use median aggregation with quartile-based

### DIFF
--- a/src/lib/components/overview-page/CommitGraph.svelte
+++ b/src/lib/components/overview-page/CommitGraph.svelte
@@ -2,7 +2,6 @@
     import Graph from "$lib/components/overview-page/Graph.svelte";
     import ContributorCards from "$lib/components/overview-page/ContributorCards.svelte";
     import DropdownTintedMedium from "$lib/components/global/DropdownTintedMedium.svelte";
-    import ButtonTintedMedium from "$lib/components/global/ButtonTintedMedium.svelte";
     import type { Contributor } from "$lib/metrics";
 
     let {
@@ -25,6 +24,8 @@
 
     let sidebar_open = $state(false);
     let bookmarked_repo: { repo_name: string; repo_url: string }[] = [];
+    let aggregation_options = ["mean", "median"];
+    let selected_aggregation = $state("mean");
 
     function toggle_sidebar() {
         sidebar_open = !sidebar_open;
@@ -39,12 +40,10 @@
             disabled={false}
         />
 
-        <ButtonTintedMedium
-            label="mean"
-            label_class="body"
-            icon_first={false}
-            icon="chevron-down"
-            width="12rem"
+        <DropdownTintedMedium
+            options={aggregation_options}
+            bind:selected={selected_aggregation}
+            disabled={false}
         />
     </div>
     <Graph

--- a/src/lib/components/overview-page/CommitGraph.svelte
+++ b/src/lib/components/overview-page/CommitGraph.svelte
@@ -12,6 +12,8 @@
         end_date,
         criteria,
         selected_criteria = $bindable(),
+        aggregation_options,
+        selected_aggregation = $bindable(),
     }: {
         contributors: Contributor[];
         branches: String[];
@@ -20,12 +22,12 @@
         end_date?: string;
         criteria: string[];
         selected_criteria: string;
+        aggregation_options: string[];
+        selected_aggregation: string;
     } = $props();
 
     let sidebar_open = $state(false);
     let bookmarked_repo: { repo_name: string; repo_url: string }[] = [];
-    let aggregation_options = ["mean", "median"];
-    let selected_aggregation = $state("mean");
 
     function toggle_sidebar() {
         sidebar_open = !sidebar_open;

--- a/src/lib/components/overview-page/CommitGraph.svelte
+++ b/src/lib/components/overview-page/CommitGraph.svelte
@@ -52,6 +52,7 @@
         {start_date}
         {end_date}
         metric={selected_criteria}
+        aggregation={selected_aggregation}
     />
 
     <ContributorCards
@@ -60,6 +61,7 @@
         start_date={start_date ?? ""}
         end_date={end_date ?? ""}
         metric={selected_criteria}
+        aggregation={selected_aggregation}
     />
 </main>
 

--- a/src/lib/components/overview-page/ContributorAnalysis.svelte
+++ b/src/lib/components/overview-page/ContributorAnalysis.svelte
@@ -75,18 +75,15 @@
             return;
         }
 
-        const working_dir = await invoke("get_working_directory");
-        const full_repo_path = `${working_dir}/repositories/${repo_path}`;
-
         if (repo_path) {
             try {
                 if (email_mapping) {
                     await invoke("get_ai_summary_with_config", {
-                        path: full_repo_path,
+                        path: repo_path,
                         configJson: email_mapping,
                     });
                 } else {
-                    await invoke("get_ai_summary", { path: full_repo_path });
+                    await invoke("get_ai_summary", { path: repo_path });
                 }
             } catch (e) {
                 error("Error occurred: " + e);
@@ -134,14 +131,14 @@
             if (aggregation === "mean") {
                 scaling_factor = calculate_scaling_factor(
                     num_commits,
-                    commit_mean(),
-                    sd()
+                    commit_mean,
+                    sd
                 );
             } else {
                 scaling_factor = calculate_quartile_scaling_factor(
                     num_commits,
-                    quartiles().q1,
-                    quartiles().q3
+                    quartiles.q1,
+                    quartiles.q3
                 );
             }
 

--- a/src/lib/components/overview-page/ContributorCards.svelte
+++ b/src/lib/components/overview-page/ContributorCards.svelte
@@ -7,6 +7,7 @@
         get_user_total_deletions,
         get_user_absolute_diff,
         calculate_scaling_factor,
+        calculate_quartile_scaling_factor,
         get_average_commits,
         get_average_commit_size,
         get_average_absolute_diff,
@@ -65,6 +66,22 @@
 
     let sd_value: number = $derived(get_sd(users, metric));
 
+    let quartiles = $derived(() => {
+        if (aggregation === "median") {
+            switch (metric) {
+                case "commits":
+                    return get_commit_quartiles(users);
+                case "commit_size":
+                    return get_commit_size_quartiles(users);
+                case "absolute_diff":
+                    return get_absolute_diff_quartiles(users);
+                default:
+                    return get_commit_quartiles(users);
+            }
+        }
+        return { q1: 0, median: 0, q3: 0 };
+    });
+
     let people_with_metrics = $derived(
         users.map((user: Contributor) => {
             // Get the appropriate data value based on selected metric
@@ -87,11 +104,20 @@
                     data_value = get_user_total_commits(user);
             }
 
-            const scaling_factor = calculate_scaling_factor(
-                data_value,
-                metric_centrality(),
-                aggregation === "mean" ? sd_value : 0
-            );
+            let scaling_factor: number;
+            if (aggregation === "mean") {
+                scaling_factor = calculate_scaling_factor(
+                    data_value,
+                    metric_centrality(),
+                    sd_value
+                );
+            } else {
+                scaling_factor = calculate_quartile_scaling_factor(
+                    data_value,
+                    quartiles().q1,
+                    quartiles().q3
+                );
+            }
 
             return {
                 username: user.username,

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -23,7 +23,9 @@
     let chart_container: HTMLElement;
     let chart: echarts.ECharts;
     let filtered_people: UserDisplayData[] = $state([]);
-    let processed_people: (UserDisplayData & { y_value?: number })[] = $state([]);
+    let processed_people: (UserDisplayData & { y_value?: number })[] = $state(
+        []
+    );
     let is_staggered_mode = $state(false);
     let chart_height = $state(380);
     let is_transitioning = $state(false);
@@ -94,7 +96,10 @@
                 y_value: 30 + index * 40,
             }));
         } else {
-            processed_people = filtered_people.map((p) => ({ ...p, y_value: 1.25 }));
+            processed_people = filtered_people.map((p) => ({
+                ...p,
+                y_value: 1.25,
+            }));
         }
     });
     $effect(() => {
@@ -357,7 +362,9 @@
                                       fontWeight: "900",
                                       fill: "#fff",
                                       font: 'bold 16px "DM Sans ExtraBold", sans-serif',
-                                      textAlign: is_rightmost ? "right" : "left",
+                                      textAlign: is_rightmost
+                                          ? "right"
+                                          : "left",
                                       textVerticalAlign: "top",
                                   },
                                   x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
@@ -372,7 +379,9 @@
                                       fontSize: 14,
                                       fill: "#fff",
                                       font: 'bold 16px "DM Sans", sans-serif',
-                                      textAlign: is_rightmost ? "right" : "left",
+                                      textAlign: is_rightmost
+                                          ? "right"
+                                          : "left",
                                       textVerticalAlign: "top",
                                   },
                                   x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
@@ -446,7 +455,10 @@
                 show: false,
                 min: 0,
                 max: is_staggered_mode
-                    ? Math.max(30 + (processed_people.length - 1) * 40 + 100, 2.5)
+                    ? Math.max(
+                          30 + (processed_people.length - 1) * 40 + 100,
+                          2.5
+                      )
                     : 2.5,
             },
             series: [
@@ -561,6 +573,5 @@
     .chart-container {
         width: 100%;
         font-family: "DM Sans", sans-serif;
-        padding-bottom: 2rem;
     }
 </style>

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -23,9 +23,7 @@
     let chart_container: HTMLElement;
     let chart: echarts.ECharts;
     let filtered_people: UserDisplayData[] = $state([]);
-    let processed_people: (UserDisplayData & { y_value?: number })[] = $state(
-        []
-    );
+    let processed_people: (UserDisplayData & { y_value?: number })[] = $state([]);
     let is_staggered_mode = $state(false);
     let chart_height = $state(380);
     let is_transitioning = $state(false);
@@ -96,10 +94,7 @@
                 y_value: 30 + index * 40,
             }));
         } else {
-            processed_people = filtered_people.map((p) => ({
-                ...p,
-                y_value: 1,
-            }));
+            processed_people = filtered_people.map((p) => ({ ...p, y_value: 1.25 }));
         }
     });
     $effect(() => {
@@ -113,7 +108,7 @@
         const old_height = chart_height;
         const new_height = is_staggered_mode
             ? 100 + filtered_people.length * 80
-            : 400;
+            : 380;
         chart_height = new_height;
 
         // Trigger chart resize when height changes
@@ -336,19 +331,19 @@
                         type: "image",
                         style: {
                             image: person.image,
-                            width: is_staggered_mode ? 50 : 40,
-                            height: is_staggered_mode ? 50 : 40,
+                            width: is_staggered_mode ? 50 : 50,
+                            height: is_staggered_mode ? 50 : 50,
                         },
-                        x: x - (is_staggered_mode ? 25 : 20),
-                        y: y - (is_staggered_mode ? 25 : 20),
+                        x: x - (is_staggered_mode ? 25 : 25),
+                        y: y - (is_staggered_mode ? 25 : 25),
                         z: 3,
                         silent: false,
                         clipPath: {
                             type: "circle",
                             shape: {
-                                cx: is_staggered_mode ? 25 : 20,
-                                cy: is_staggered_mode ? 25 : 20,
-                                r: is_staggered_mode ? 25 : 20,
+                                cx: is_staggered_mode ? 25 : 25,
+                                cy: is_staggered_mode ? 25 : 25,
+                                r: is_staggered_mode ? 25 : 25,
                             },
                         },
                     },
@@ -362,9 +357,7 @@
                                       fontWeight: "900",
                                       fill: "#fff",
                                       font: 'bold 16px "DM Sans ExtraBold", sans-serif',
-                                      textAlign: is_rightmost
-                                          ? "right"
-                                          : "left",
+                                      textAlign: is_rightmost ? "right" : "left",
                                       textVerticalAlign: "top",
                                   },
                                   x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
@@ -379,9 +372,7 @@
                                       fontSize: 14,
                                       fill: "#fff",
                                       font: 'bold 16px "DM Sans", sans-serif',
-                                      textAlign: is_rightmost
-                                          ? "right"
-                                          : "left",
+                                      textAlign: is_rightmost ? "right" : "left",
                                       textVerticalAlign: "top",
                                   },
                                   x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
@@ -455,10 +446,7 @@
                 show: false,
                 min: 0,
                 max: is_staggered_mode
-                    ? Math.max(
-                          30 + (processed_people.length - 1) * 40 + 100,
-                          2.5
-                      )
+                    ? Math.max(30 + (processed_people.length - 1) * 40 + 100, 2.5)
                     : 2.5,
             },
             series: [
@@ -482,7 +470,7 @@
                         p.y_value,
                         p.username,
                     ]),
-                    symbolSize: 32,
+                    symbolSize: 40,
                     z: 10,
                     animation: true,
                     animationDuration: 800,

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -110,6 +110,8 @@
     });
     $effect(() => {
         metric;
+        aggregation;
+        contributors;
         if (chart) {
             set_chart_options();
         }

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -194,7 +194,10 @@
             axis_min_val,
             0,
         ])[0];
-        const grid_right_px = chart.convertToPixel({ gridIndex: 0 }, [x_max, 0])[0];
+        const grid_right_px = chart.convertToPixel({ gridIndex: 0 }, [
+            x_max,
+            0,
+        ])[0];
         const drawable_width = grid_right_px - margin_left;
         const container_width = chart_container.clientWidth;
         const margin_right = container_width - grid_right_px;

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -377,10 +377,10 @@
             const x = is_staggered_mode
                 ? baseX
                 : baseX + (person.offsetIndex ? person.offsetIndex * 16 : 0);
-            
+
             let scaling_factor: number;
 
-            if (aggregation === 'mean') {
+            if (aggregation === "mean") {
                 scaling_factor = calculate_scaling_factor(
                     person.data_to_display,
                     metric_mean,

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -187,17 +187,26 @@
         const full_height = x_axis_y - grid_top;
         const tint_height = is_staggered_mode
             ? x_axis_y - tint_start_y
-            : full_height * 0.9;
+            : full_height;
 
-        const margin_left = 40; // px
-        const margin_right = 40; // px
+        const axis_min_val = x_min - 1 < 0 ? 0 : x_min;
+        const margin_left = chart.convertToPixel({ gridIndex: 0 }, [
+            axis_min_val,
+            0,
+        ])[0];
+        const grid_right_px = chart.convertToPixel({ gridIndex: 0 }, [x_max, 0])[0];
+        const drawable_width = grid_right_px - margin_left;
         const container_width = chart_container.clientWidth;
-        const drawable_width = container_width - margin_left - margin_right;
+        const margin_right = container_width - grid_right_px;
 
         function x_scale(value: number) {
+            if (x_max - axis_min_val === 0) {
+                return margin_left;
+            }
             return (
                 margin_left +
-                ((value - x_min) / (x_max - x_min)) * drawable_width
+                ((value - axis_min_val) / (x_max - axis_min_val)) *
+                    drawable_width
             );
         }
 

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -10,6 +10,7 @@
         get_users_total_commits,
         get_users_avg_commit_size,
         get_users_absolute_diff,
+        calculate_scaling_factor,
         type Contributor,
         type UserDisplayData,
     } from "$lib/metrics";
@@ -22,6 +23,12 @@
     let chart_container: HTMLElement;
     let chart: echarts.ECharts;
     let filtered_people: UserDisplayData[] = $state([]);
+    let processed_people: (UserDisplayData & { y_value?: number })[] = $state(
+        []
+    );
+    let is_staggered_mode = $state(false);
+    let chart_height = $state(380);
+    let is_transitioning = $state(false);
     let x_min: number = $state(0);
     let x_max: number = $state(1);
     let metric_mean: number = $state(0);
@@ -80,6 +87,74 @@
         }
     });
     $effect(() => {
+        if (is_staggered_mode) {
+            const sorted_people = [...filtered_people].sort(
+                (a, b) => a.data_to_display - b.data_to_display
+            );
+            processed_people = sorted_people.map((person, index) => ({
+                ...person,
+                y_value: 30 + index * 40,
+            }));
+        } else {
+            processed_people = filtered_people.map((p) => ({
+                ...p,
+                y_value: 1,
+            }));
+        }
+    });
+    $effect(() => {
+        metric;
+        if (chart) {
+            set_chart_options();
+        }
+    });
+    $effect(() => {
+        // Update chart height based on mode and number of contributors
+        const old_height = chart_height;
+        const new_height = is_staggered_mode
+            ? 100 + filtered_people.length * 80
+            : 400;
+        chart_height = new_height;
+
+        // Trigger chart resize when height changes
+        if (chart && old_height !== new_height) {
+            // Use requestAnimationFrame to wait for DOM update
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    // First resize immediately
+                    chart.resize();
+
+                    // Multiple gradual updates during the transition (every 25ms)
+                    const updateIntervals = [];
+                    for (let i = 25; i <= 750; i += 25) {
+                        updateIntervals.push(i);
+                    }
+
+                    updateIntervals.forEach((delay, index) => {
+                        setTimeout(() => {
+                            chart.resize();
+
+                            // Update graphics only when not transitioning
+                            if (!is_transitioning) {
+                                update_graphics();
+                            }
+
+                            // Only clear and reset options on the final update
+                            if (index === updateIntervals.length - 1) {
+                                chart.clear();
+                                set_chart_options();
+                                // Re-enable contributor icons after transition completes
+                                is_transitioning = false;
+                                // Call updateGraphics to render icons now that transition is complete
+                                update_graphics();
+                            }
+                        }, delay);
+                    });
+                });
+            });
+        }
+    });
+    $effect(() => {
         sd = get_sd(contributors, metric);
     });
     $effect(() => {
@@ -97,20 +172,22 @@
                       { label: "+2σ", value: ref_point_values[4] },
                   ];
     });
-    $effect(() => {
-        metric;
-        if (chart) {
-            set_chart_options();
-        }
-    });
 
     function update_graphics() {
-        if (!chart) return;
-        const grid_top = chart.convertToPixel({ gridIndex: 0 }, [0, 6])[1];
+        if (!chart || is_transitioning) return;
+        const grid_top = chart.convertToPixel({ gridIndex: 0 }, [
+            0,
+            is_staggered_mode
+                ? Math.max(30 + (processed_people.length - 1) * 40 + 100, 2.5)
+                : 2.5,
+        ])[1];
         const x_axis_y = chart.convertToPixel({ gridIndex: 0 }, [0, 0])[1];
 
+        const tint_start_y = is_staggered_mode ? 40 : grid_top;
         const full_height = x_axis_y - grid_top;
-        const tint_height = full_height * 0.9;
+        const tint_height = is_staggered_mode
+            ? x_axis_y - tint_start_y
+            : full_height * 0.9;
 
         const margin_left = 40; // px
         const margin_right = 40; // px
@@ -159,7 +236,7 @@
             type: "rect",
             shape: {
                 x: middle_tint.x,
-                y: x_axis_y - tint_height,
+                y: tint_start_y,
                 width: middle_tint.width,
                 height: tint_height,
             },
@@ -174,7 +251,7 @@
             type: "rect",
             shape: {
                 x: left_tint.x,
-                y: x_axis_y - tint_height,
+                y: tint_start_y,
                 width: left_tint.width,
                 height: tint_height,
             },
@@ -189,7 +266,7 @@
             type: "rect",
             shape: {
                 x: right_tint.x,
-                y: x_axis_y - tint_height,
+                y: tint_start_y,
                 width: right_tint.width,
                 height: tint_height,
             },
@@ -209,7 +286,7 @@
                         type: "line",
                         shape: {
                             x1: x,
-                            y1: grid_top,
+                            y1: is_staggered_mode ? 40 : grid_top,
                             x2: x,
                             y2: x_axis_y,
                         },
@@ -232,19 +309,26 @@
                             textVerticalAlign: "bottom",
                         },
                         x: x,
-                        y: grid_top - 8,
+                        y: is_staggered_mode ? 20 : grid_top - 8,
                         z: 2,
                     },
                 ],
             };
         });
-        const user_graphics = filtered_people.map((person: UserDisplayData) => {
+        const user_graphics = processed_people.map((person: any) => {
             const [baseX, y] = chart.convertToPixel({ gridIndex: 0 }, [
                 person.data_to_display,
-                1,
+                person.y_value,
             ]);
-            const x =
-                baseX + (person.offsetIndex ? person.offsetIndex * 16 : 0);
+            const x = is_staggered_mode
+                ? baseX
+                : baseX + (person.offsetIndex ? person.offsetIndex * 16 : 0);
+            const scaling_factor = calculate_scaling_factor(
+                person.data_to_display,
+                metric_mean,
+                sd
+            );
+            const is_rightmost = person.data_to_display === x_max;
             return {
                 type: "group",
                 children: [
@@ -252,22 +336,60 @@
                         type: "image",
                         style: {
                             image: person.image,
-                            width: 40,
-                            height: 40,
+                            width: is_staggered_mode ? 50 : 40,
+                            height: is_staggered_mode ? 50 : 40,
                         },
-                        x: x - 20,
-                        y: y - 20,
+                        x: x - (is_staggered_mode ? 25 : 20),
+                        y: y - (is_staggered_mode ? 25 : 20),
                         z: 3,
                         silent: false,
                         clipPath: {
                             type: "circle",
                             shape: {
-                                cx: 20,
-                                cy: 20,
-                                r: 20,
+                                cx: is_staggered_mode ? 25 : 20,
+                                cy: is_staggered_mode ? 25 : 20,
+                                r: is_staggered_mode ? 25 : 20,
                             },
                         },
                     },
+                    ...(is_staggered_mode
+                        ? [
+                              {
+                                  type: "text",
+                                  style: {
+                                      text: person.username,
+                                      fontSize: 14,
+                                      fontWeight: "900",
+                                      fill: "#fff",
+                                      font: 'bold 16px "DM Sans ExtraBold", sans-serif',
+                                      textAlign: is_rightmost
+                                          ? "right"
+                                          : "left",
+                                      textVerticalAlign: "top",
+                                  },
+                                  x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
+                                  y: y - 15,
+                                  z: 2,
+                              },
+
+                              {
+                                  type: "text",
+                                  style: {
+                                      text: `Scaling Factor: ${scaling_factor.toFixed(1)}`,
+                                      fontSize: 14,
+                                      fill: "#fff",
+                                      font: 'bold 16px "DM Sans", sans-serif',
+                                      textAlign: is_rightmost
+                                          ? "right"
+                                          : "left",
+                                      textVerticalAlign: "top",
+                                  },
+                                  x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
+                                  y: y + 5,
+                                  z: 2,
+                              },
+                          ]
+                        : []),
                 ],
             };
         });
@@ -285,12 +407,16 @@
     function set_chart_options() {
         const option = {
             backgroundColor: "transparent", //#222',
+            animation: true,
+            animationDuration: 800,
+            animationEasing: "cubicInOut" as const,
+            animationDelay: 0,
             grid: {
-                top: "50%",
-                bottom: 100,
-                left: 40,
-                right: 40,
-                containLabel: false,
+                top: 30,
+                bottom: is_staggered_mode ? 80 : 80,
+                left: "5%",
+                right: "5%",
+                containLabel: true,
             },
             xAxis: {
                 type: "value",
@@ -328,28 +454,39 @@
             yAxis: {
                 show: false,
                 min: 0,
-                max: 2.5,
+                max: is_staggered_mode
+                    ? Math.max(
+                          30 + (processed_people.length - 1) * 40 + 100,
+                          2.5
+                      )
+                    : 2.5,
             },
             series: [
                 {
                     type: "scatter",
-                    data: filtered_people.map((p: UserDisplayData) => [
+                    data: processed_people.map((p: any) => [
                         p.data_to_display,
-                        1,
+                        p.y_value,
                     ]),
                     symbolSize: 0,
                     z: 3,
+                    animation: true,
+                    animationDuration: 800,
+                    animationEasing: "cubicInOut" as const,
                 },
                 {
                     name: "hoverPoints",
                     type: "scatter",
-                    data: filtered_people.map((p: UserDisplayData) => [
+                    data: processed_people.map((p: any) => [
                         p.data_to_display,
-                        1,
+                        p.y_value,
                         p.username,
                     ]),
                     symbolSize: 32,
                     z: 10,
+                    animation: true,
+                    animationDuration: 800,
+                    animationEasing: "cubicInOut" as const,
                     itemStyle: {
                         color: "transparent",
                     },
@@ -370,7 +507,7 @@
                 formatter: function (params: any) {
                     if (params.seriesName === "hoverPoints") {
                         const username = params.data[2];
-                        const person = filtered_people.find(
+                        const person = processed_people.find(
                             (p: any) => p.username === username
                         );
                         if (!person) return username;
@@ -393,6 +530,27 @@
     onMount(() => {
         chart = echarts.init(chart_container);
         set_chart_options();
+
+        chart.on("click", (params: any) => {
+            if (
+                params.componentType === "graphic" &&
+                params.componentSubType === "image"
+            ) {
+                return;
+            }
+
+            chart.dispatchAction({ type: "hideTip" });
+
+            is_transitioning = true;
+            chart.clear();
+
+            set_chart_options();
+
+            requestAnimationFrame(() => {
+                is_staggered_mode = !is_staggered_mode;
+            });
+        });
+
         resize_handler = () => {
             chart.resize();
             update_graphics();
@@ -405,12 +563,15 @@
     });
 </script>
 
-<div bind:this={chart_container} class="chart-container"></div>
+<div
+    bind:this={chart_container}
+    class="chart-container"
+    style="height: {chart_height}px; transition: height 0.6s cubic-bezier(0.4, 0.0, 0.2, 1);"
+></div>
 
 <style>
     .chart-container {
         width: 100%;
-        height: 500px;
         font-family: "DM Sans", sans-serif;
         padding-bottom: 2rem;
     }

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -369,6 +369,20 @@ export function calculate_scaling_factor(
     }
 }
 
+export function calculate_quartile_scaling_factor(
+    value: number,
+    q1: number,
+    q3: number
+): number {
+    if (value < q1) {
+        return 0.9;
+    } else if (value > q3) {
+        return 1.1;
+    } else {
+        return 1.0;
+    }
+}
+
 export function get_metric_min_max(
     users: Contributor[],
     metric: string

--- a/src/lib/utils/grading.ts
+++ b/src/lib/utils/grading.ts
@@ -5,6 +5,7 @@ import {
     get_average_commits,
     get_sd,
     calculate_scaling_factor,
+    calculate_quartile_scaling_factor,
 } from "$lib/metrics";
 
 import { parse_rows, stringify_rows, parse_number_cell } from "$lib/utils/csv";

--- a/src/lib/utils/grading.ts
+++ b/src/lib/utils/grading.ts
@@ -6,6 +6,7 @@ import {
     get_sd,
     calculate_scaling_factor,
     calculate_quartile_scaling_factor,
+    get_commit_quartiles,
 } from "$lib/metrics";
 
 import { parse_rows, stringify_rows, parse_number_cell } from "$lib/utils/csv";
@@ -100,7 +101,8 @@ function find_contributor_by_email(
  */
 export function populate_using_metrics(
     contributors: Contributor[],
-    uploaded: UploadedGradingFile
+    uploaded: UploadedGradingFile,
+    aggregation: string
 ): string {
     const { headers, delimiter, rows } = parse_rows(uploaded.bytes);
 
@@ -111,21 +113,33 @@ export function populate_using_metrics(
     if (!out_headers.includes(FACTOR_COL)) out_headers.push(FACTOR_COL);
     if (!out_headers.includes(SCALED_COL)) out_headers.push(SCALED_COL);
 
-    const mean = get_average_commits(contributors);
-    const sd = get_sd(contributors);
-
     const email_key = headers.find(
         (h) => h.trim().toLowerCase() === "email address"
     );
     const grade_key = headers.find((h) => h.trim().toLowerCase() === "grade");
 
+    let factor_calculator: (c: Contributor) => number;
+
+    if (aggregation === "mean") {
+        const mean = get_average_commits(contributors);
+        const sd = get_sd(contributors, "commits");
+        factor_calculator = (c: Contributor) =>
+            calculate_scaling_factor(c.total_commits, mean, sd);
+    } else {
+        const quartiles = get_commit_quartiles(contributors);
+        factor_calculator = (c: Contributor) =>
+            calculate_quartile_scaling_factor(
+                c.total_commits,
+                quartiles.q1,
+                quartiles.q3
+            );
+    }
+
     const out_rows = rows.map((row) => {
         const email = email_key ? row[email_key] : "";
         const c = find_contributor_by_email(contributors, email);
 
-        const factor_str = c
-            ? calculate_scaling_factor(c.total_commits, mean, sd).toFixed(2)
-            : "NA";
+        const factor_str = c ? factor_calculator(c).toFixed(2) : "NA";
 
         const raw = parse_number_cell(grade_key ? row[grade_key] : undefined);
         const scaled =
@@ -142,11 +156,13 @@ export function populate_using_metrics(
 
 export async function download_populated_file(
     contributors: Contributor[],
-    uploaded: UploadedGradingFile
+    uploaded: UploadedGradingFile,
+    aggregation: string
 ): Promise<void> {
     const { text, matched, total } = populate_with_stats(
         contributors,
-        uploaded
+        uploaded,
+        aggregation
     );
     await save_text_file_native("populated-grading-sheet.csv", text);
     await info(`[grading] matched ${matched}/${total} rows`);
@@ -154,7 +170,8 @@ export async function download_populated_file(
 
 export function populate_with_stats(
     contributors: Contributor[],
-    uploaded: UploadedGradingFile
+    uploaded: UploadedGradingFile,
+    aggregation: string
 ): { text: string; matched: number; total: number } {
     const { headers, rows } = parse_rows(uploaded.bytes);
 
@@ -169,7 +186,7 @@ export function populate_with_stats(
         if (find_contributor_by_email(contributors, email)) matched++;
     }
 
-    const text = populate_using_metrics(contributors, uploaded);
+    const text = populate_using_metrics(contributors, uploaded, aggregation);
     return { text, matched, total: rows.length };
 }
 

--- a/src/routes/overview-page/+page.svelte
+++ b/src/routes/overview-page/+page.svelte
@@ -41,6 +41,8 @@
     //let criteria = ["total commits", "lines of code", "lines/commit"];
     let criteria: string[] = ["commits", "commit_size", "absolute_diff"];
     let selected_criteria = $state(criteria[0]);
+    let aggregation_options = ["mean", "median"];
+    let selected_aggregation = $state("mean");
 
     let selected_view: string = $state("overview");
 
@@ -218,6 +220,8 @@
                 {end_date}
                 {criteria}
                 bind:selected_criteria
+                {aggregation_options}
+                bind:selected_aggregation
             />
         {/key}
     {:else if selected_view === "analysis"}
@@ -227,6 +231,7 @@
             {email_mapping}
             {source_type}
             {selected_criteria}
+            aggregation={selected_aggregation}
         />
     {/if}
 

--- a/src/routes/overview-page/+page.svelte
+++ b/src/routes/overview-page/+page.svelte
@@ -95,7 +95,11 @@
             return;
         }
 
-        await download_populated_file(contributors, current_upload);
+        await download_populated_file(
+            contributors,
+            current_upload,
+            selected_aggregation
+        );
         void info("[download] populated file saved");
     }
 


### PR DESCRIPTION
**Changes**
Added median aggregation option with quartile-based scaling system across all overview components:
- **Median Calculations** - Added functions to calculate median and quartiles (Q1, Q3) for commits, commit size, and absolute difference metrics in src/lib/metrics.ts
- **Quartile Scaling Logic** - Implemented calculate_quartile_scaling_factor with scaling rules: above Q3 = 1.1x, below Q1 = 0.9x, between Q1-Q3 = 1.0x
- **Graph Component Updates** - Modified Graph.svelte to display quartile reference lines (Min, Q1, Median, Q3, Max) and background tinting for interquartile range when median selected
- **Contributor Cards Integration** - Updated ContributorCards.svelte to calculate and display median-based values and scaling factors
- **Grading Sheet Compatibility** - Updated grading utility functions to apply correct scaling method based on selected aggregation for downloaded marking sheets
- **State Management** - Lifted aggregation state to parent component enabling consistent behaviour across Overview and Contribution Analysis tabs
- **Chart Reactivity** - Fixed chart rendering dependencies to automatically refresh when aggregation method or contributor data changes

The aggregation dropdown now allows switching between "mean" (standard deviation-based scaling) and "median" (quartile-based scaling) views. All components including graphs, cards, analysis views, and exported grading sheets respect the selected aggregation method. Background tinting adapts to highlight different statistical ranges: σ-bands for mean view and interquartile range for median view.