### PR TITLE
feat: Profile icons generated from contributor username

### DIFF
--- a/src-tauri/src/contributor.rs
+++ b/src-tauri/src/contributor.rs
@@ -299,10 +299,9 @@ fn find_branch_oid(repo: &Repository, branch: &str) -> Result<Oid, String> {
 }
 
 fn generate_profile_bg_colour(username: &str) -> String {
-    let hash = username
-        .as_bytes()
-        .iter()
-        .fold(0usize, |hash, byte| (*byte as usize) + ((hash << 5) - hash));
+    let hash = username.as_bytes().iter().fold(0usize, |hash, byte| {
+        (*byte as usize) + (hash << 5).wrapping_sub(hash)
+    });
 
     (0..=3)
         .map(|i| (hash >> (i * 8)) & 0xff)

--- a/src-tauri/src/contributor.rs
+++ b/src-tauri/src/contributor.rs
@@ -184,9 +184,7 @@ pub async fn get_contributor_info(
         //let login_name = author_signature.name().unwrap_or("Unknown").to_string();
         //let gravatar_url = format!("https://www.gravatar.com/avatar/{gravatar_hash:x}?d=identicon");
 
-        let username = author_signature
-            .name()
-            .unwrap_or("unknown");
+        let username = author_signature.name().unwrap_or("unknown");
 
         let initials = username
             .split_whitespace()
@@ -246,7 +244,7 @@ pub async fn get_contributor_info(
                 total_commits: 0,
                 additions: 0,
                 deletions: 0,
-                profile_bg_colour: profile_bg_colour,
+                profile_bg_colour,
                 username_initials: initials,
                 ai_summary: String::from(""),
             });
@@ -300,28 +298,11 @@ fn find_branch_oid(repo: &Repository, branch: &str) -> Result<Oid, String> {
     Err(format!("Branch '{branch}' not found as local or remote"))
 }
 
-//function generateBackground(name) {
-//    let hash = 0;
-//    let i;
-//
-//    for (i = 0; i < name.length; i += 1) {
-//      hash = name.charCodeAt(i) + ((hash << 5) - hash);
-//    }
-//
-//    let color = "#";
-//
-//    for (i = 0; i < 3; i += 1) {
-//      const value = (hash >> (i * 8)) & 0xff;
-//      color += `00${value.toString(16)}`.slice(-2);
-//    }
-//
-//    return color;
-//  }
 fn generate_profile_bg_colour(username: &str) -> String {
     let hash = username
         .as_bytes()
         .iter()
-        .fold(0 as usize, |hash, byte| (*byte as usize) + ((hash << 5) - hash));
+        .fold(0usize, |hash, byte| (*byte as usize) + ((hash << 5) - hash));
 
     (0..=3)
         .map(|i| (hash >> (i * 8)) & 0xff)

--- a/src-tauri/src/contributor.rs
+++ b/src-tauri/src/contributor.rs
@@ -16,7 +16,7 @@ pub struct Contributor {
     pub total_commits: u64,
     pub additions: u64,
     pub deletions: u64,
-    pub profile_bg_colour: String,
+    pub profile_colour: String,
     pub username_initials: String,
     pub ai_summary: String,
 }
@@ -61,7 +61,7 @@ pub async fn group_contributors_by_config(
                             contacts.push(email.to_string());
 
                             if profile_bg_colour.is_empty() {
-                                profile_bg_colour = contrib.profile_bg_colour.clone();
+                                profile_bg_colour = contrib.profile_colour.clone();
                             }
 
                             if username_initials.is_empty() {
@@ -79,7 +79,7 @@ pub async fn group_contributors_by_config(
                     total_commits,
                     additions,
                     deletions,
-                    profile_bg_colour,
+                    profile_colour: profile_bg_colour,
                     username_initials,
                     ai_summary,
                 });
@@ -244,7 +244,7 @@ pub async fn get_contributor_info(
                 total_commits: 0,
                 additions: 0,
                 deletions: 0,
-                profile_bg_colour,
+                profile_colour: profile_bg_colour,
                 username_initials: initials,
                 ai_summary: String::from(""),
             });
@@ -264,7 +264,7 @@ pub async fn get_contributor_info(
                         total_commits: entry.total_commits,
                         additions: entry.additions,
                         deletions: entry.deletions,
-                        profile_bg_colour: entry.profile_bg_colour.clone(),
+                        profile_colour: entry.profile_colour.clone(),
                         username_initials: entry.username_initials.clone(),
                         ai_summary: String::from(""),
                     };
@@ -303,8 +303,9 @@ fn generate_profile_bg_colour(username: &str) -> String {
         (*byte as usize) + (hash << 5).wrapping_sub(hash)
     });
 
-    (0..=3)
-        .map(|i| (hash >> (i * 8)) & 0xff)
-        .map(|x| format!("{x:x}"))
-        .collect::<String>()
+    let r: u8 = u8::try_from(hash & 0xff).unwrap_or(0);
+    let g: u8 = u8::try_from((hash >> 8) & 0xff).unwrap_or(0);
+    let b: u8 = u8::try_from((hash >> 16) & 0xff).unwrap_or(0);
+
+    format!("#{r:x}{g:x}{b:x}")
 }

--- a/src-tauri/src/contributor.rs
+++ b/src-tauri/src/contributor.rs
@@ -307,5 +307,5 @@ fn generate_profile_bg_colour(username: &str) -> String {
     let g: u8 = u8::try_from((hash >> 8) & 0xff).unwrap_or(0);
     let b: u8 = u8::try_from((hash >> 16) & 0xff).unwrap_or(0);
 
-    format!("#{r:x}{g:x}{b:x}")
+    format!("#{r:02x}{g:02x}{b:02x}")
 }

--- a/src/lib/components/global/ContributorCard.svelte
+++ b/src/lib/components/global/ContributorCard.svelte
@@ -1,5 +1,17 @@
 <script lang="ts">
-    let { username, image, scaling_factor, content } = $props();
+    let {
+        username,
+        profile_colour,
+        initials,
+        scaling_factor,
+        content,
+    }: {
+        username: string;
+        profile_colour: string;
+        initials: string;
+        scaling_factor: number;
+        content: () => any;
+    } = $props();
 </script>
 
 <!--
@@ -19,7 +31,12 @@ This is a contributor card component that displays a user's profile information.
 -->
 
 <div class="profile-card">
-    <img class="profile-avatar" src={image} alt={username} />
+    <!-- <img class="profile-avatar" src={image} alt={username} /> -->
+    <div class="profile-avatar" style:background={profile_colour}>
+        <div class="profile-initials">
+            {initials}
+        </div>
+    </div>
     <div class="contents">
         <!-- header -->
         <div class="profile-details">
@@ -48,12 +65,24 @@ This is a contributor card component that displays a user's profile information.
     }
 
     .profile-avatar {
-        width: 2rem;
-        height: 2rem;
-        border-radius: 50%;
+        display: flex;
         flex-shrink: 0;
         object-fit: cover;
         background: #ccc;
+        height: 2rem;
+        width: 2rem;
+        border-radius: 50%;
+        color: white;
+        margin: auto;
+        font-family:
+            DM Sans,
+            sans-serif;
+        font-size: 1rem;
+        font-weight: bold;
+    }
+
+    .profile-initials {
+        margin: auto;
     }
 
     .contents {

--- a/src/lib/components/global/ContributorStatsCard.svelte
+++ b/src/lib/components/global/ContributorStatsCard.svelte
@@ -3,7 +3,8 @@
 
     let {
         username,
-        image,
+        profile_colour,
+        initials,
         num_commits,
         total_lines_of_code,
         lines_per_commit,
@@ -24,7 +25,7 @@ contributor statistics.
   ```
 -->
 
-<ContributorCard {username} {image} {scaling_factor}>
+<ContributorCard {username} {profile_colour} {initials} {scaling_factor}>
     {#snippet content()}
         <div class="contents body">
             <div>{num_commits} commits</div>

--- a/src/lib/components/overview-page/ContributorAnalysis.svelte
+++ b/src/lib/components/overview-page/ContributorAnalysis.svelte
@@ -157,8 +157,7 @@
             }
 
             return {
-                username: user.bitmap_hash,
-                image: user.bitmap,
+                username: user.username,
                 analysis: analysis,
                 scaling_factor: scaling_factor.toFixed(1),
             };

--- a/src/lib/components/overview-page/ContributorCards.svelte
+++ b/src/lib/components/overview-page/ContributorCards.svelte
@@ -121,6 +121,8 @@
 
             return {
                 username: user.username,
+                profile_colour: user.profile_colour,
+                initials: user.username_initials,
                 num_commits: get_user_total_commits(user),
                 total_lines_of_code: get_user_total_lines_of_code(user),
                 lines_per_commit: get_user_lines_per_commit(user),

--- a/src/lib/components/overview-page/ContributorCards.svelte
+++ b/src/lib/components/overview-page/ContributorCards.svelte
@@ -121,7 +121,6 @@
 
             return {
                 username: user.username,
-                image: user.bitmap,
                 num_commits: get_user_total_commits(user),
                 total_lines_of_code: get_user_total_lines_of_code(user),
                 lines_per_commit: get_user_lines_per_commit(user),

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -399,23 +399,27 @@
                 type: "group",
                 children: [
                     {
-                        type: "image",
+                        type: "circle",
                         style: {
-                            image: person.image,
-                            width: is_staggered_mode ? 50 : 50,
-                            height: is_staggered_mode ? 50 : 50,
+                            fill: person.profile_bg_colour,
                         },
-                        x: x - (is_staggered_mode ? 25 : 25),
-                        y: y - (is_staggered_mode ? 25 : 25),
+                        shape: {
+                            r: 22,
+                        },
+                        x,
+                        y,
                         z: 3,
                         silent: false,
-                        clipPath: {
-                            type: "circle",
-                            shape: {
-                                cx: is_staggered_mode ? 25 : 25,
-                                cy: is_staggered_mode ? 25 : 25,
-                                r: is_staggered_mode ? 25 : 25,
+                        textContent: {
+                            style: {
+                                text: person.initials,
+                                fill: "#0f0",
+                                font: 'bold 16px "DM Sans ExtraBold", sans-serif',
                             },
+                            z: 20,
+                        },
+                        textConfig: {
+                            position: "inside",
                         },
                     },
                     ...(is_staggered_mode
@@ -600,7 +604,7 @@
         chart.on("click", (params: any) => {
             if (
                 params.componentType === "graphic" &&
-                params.componentSubType === "image"
+                params.componentSubType === "circle"
             ) {
                 return;
             }

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -418,6 +418,10 @@
                 }
 
                 info(`${person.username}: ${person.profile_colour}`);
+                const z: number = idx * 4;
+                info(
+                    `idx: ${idx}, z: ${z}, +1: ${z + 1}, +2: ${z + 2}, +3: ${z + 3}`
+                );
 
                 const is_rightmost = person.data_to_display === x_max;
                 return {
@@ -433,7 +437,7 @@
                             },
                             x,
                             y,
-                            z: idx + 3,
+                            z: z + 2,
                             silent: false,
                             textContent: {
                                 style: {
@@ -443,7 +447,7 @@
                                     ),
                                     font: 'bold 16px "DM Sans ExtraBold", sans-serif',
                                 },
-                                z: idx + 4,
+                                z: z + 3,
                             },
                             textConfig: {
                                 position: "inside",
@@ -466,7 +470,7 @@
                                       },
                                       x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
                                       y: y - 15,
-                                      z: idx + 2,
+                                      z: z + 1,
                                   },
 
                                   {
@@ -483,7 +487,7 @@
                                       },
                                       x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
                                       y: y + 5,
-                                      z: idx + 2,
+                                      z: z + 1,
                                   },
                               ]
                             : []),
@@ -567,7 +571,8 @@
                         p.y_value,
                     ]),
                     symbolSize: 0,
-                    z: 3,
+                    // displays data points above stacked custom graphics
+                    z: processed_people.length * 4,
                     animation: true,
                     animationDuration: 800,
                     animationEasing: "cubicInOut" as const,
@@ -581,7 +586,8 @@
                         p.username,
                     ]),
                     symbolSize: 40,
-                    z: 10,
+                    // displays data points above stacked custom graphics
+                    z: (processed_people.length + 1) * 4,
                     animation: true,
                     animationDuration: 800,
                     animationEasing: "cubicInOut" as const,

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -369,100 +369,103 @@
                 ],
             };
         });
-        const user_graphics = processed_people.map((person: any) => {
-            const [baseX, y] = chart.convertToPixel({ gridIndex: 0 }, [
-                person.data_to_display,
-                person.y_value,
-            ]);
-            const x = is_staggered_mode
-                ? baseX
-                : baseX + (person.offsetIndex ? person.offsetIndex * 16 : 0);
-
-            let scaling_factor: number;
-
-            if (aggregation === "mean") {
-                scaling_factor = calculate_scaling_factor(
+        const user_graphics = processed_people.map(
+            (person: any, idx: number) => {
+                const [baseX, y] = chart.convertToPixel({ gridIndex: 0 }, [
                     person.data_to_display,
-                    metric_mean,
-                    sd
-                );
-            } else {
-                scaling_factor = calculate_quartile_scaling_factor(
-                    person.data_to_display,
-                    quartiles.q1,
-                    quartiles.q3
-                );
-            }
+                    person.y_value,
+                ]);
+                const x = is_staggered_mode
+                    ? baseX
+                    : baseX +
+                      (person.offsetIndex ? person.offsetIndex * 16 : 0);
 
-            const is_rightmost = person.data_to_display === x_max;
-            return {
-                type: "group",
-                children: [
-                    {
-                        type: "circle",
-                        style: {
-                            fill: person.profile_bg_colour,
-                        },
-                        shape: {
-                            r: 22,
-                        },
-                        x,
-                        y,
-                        z: 3,
-                        silent: false,
-                        textContent: {
+                let scaling_factor: number;
+
+                if (aggregation === "mean") {
+                    scaling_factor = calculate_scaling_factor(
+                        person.data_to_display,
+                        metric_mean,
+                        sd
+                    );
+                } else {
+                    scaling_factor = calculate_quartile_scaling_factor(
+                        person.data_to_display,
+                        quartiles.q1,
+                        quartiles.q3
+                    );
+                }
+
+                const is_rightmost = person.data_to_display === x_max;
+                return {
+                    type: "group",
+                    children: [
+                        {
+                            type: "circle",
                             style: {
-                                text: person.initials,
-                                fill: "#0f0",
-                                font: 'bold 16px "DM Sans ExtraBold", sans-serif',
+                                fill: person.profile_colour,
                             },
-                            z: 20,
+                            shape: {
+                                r: 20,
+                            },
+                            x,
+                            y,
+                            z: 3,
+                            silent: false,
+                            textContent: {
+                                style: {
+                                    text: person.initials,
+                                    fill: "#000",
+                                    font: 'bold 16px "DM Sans ExtraBold", sans-serif',
+                                },
+                                z: 4,
+                            },
+                            textConfig: {
+                                position: "inside",
+                            },
                         },
-                        textConfig: {
-                            position: "inside",
-                        },
-                    },
-                    ...(is_staggered_mode
-                        ? [
-                              {
-                                  type: "text",
-                                  style: {
-                                      text: person.username,
-                                      fontSize: 14,
-                                      fontWeight: "900",
-                                      fill: "#fff",
-                                      font: 'bold 16px "DM Sans ExtraBold", sans-serif',
-                                      textAlign: is_rightmost
-                                          ? "right"
-                                          : "left",
-                                      textVerticalAlign: "top",
+                        ...(is_staggered_mode
+                            ? [
+                                  {
+                                      type: "text",
+                                      style: {
+                                          text: person.username,
+                                          fontSize: 14,
+                                          fontWeight: "900",
+                                          fill: "#fff",
+                                          font: 'bold 16px "DM Sans ExtraBold", sans-serif',
+                                          textAlign: is_rightmost
+                                              ? "right"
+                                              : "left",
+                                          textVerticalAlign: "top",
+                                      },
+                                      x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
+                                      y: y - 15,
+                                      z: 2,
                                   },
-                                  x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
-                                  y: y - 15,
-                                  z: 2,
-                              },
 
-                              {
-                                  type: "text",
-                                  style: {
-                                      text: `Scaling Factor: ${scaling_factor.toFixed(1)}`,
-                                      fontSize: 14,
-                                      fill: "#fff",
-                                      font: 'bold 16px "DM Sans", sans-serif',
-                                      textAlign: is_rightmost
-                                          ? "right"
-                                          : "left",
-                                      textVerticalAlign: "top",
+                                  {
+                                      type: "text",
+                                      style: {
+                                          text: `Scaling Factor: ${scaling_factor.toFixed(1)}`,
+                                          fontSize: 14,
+                                          fill: "#fff",
+                                          font: 'bold 16px "DM Sans", sans-serif',
+                                          textAlign: is_rightmost
+                                              ? "right"
+                                              : "left",
+                                          textVerticalAlign: "top",
+                                      },
+                                      x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
+                                      y: y + 5,
+                                      z: 2,
                                   },
-                                  x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
-                                  y: y + 5,
-                                  z: 2,
-                              },
-                          ]
-                        : []),
-                ],
-            };
-        });
+                              ]
+                            : []),
+                    ],
+                };
+            }
+        );
         chart.setOption({
             graphic: [
                 tint_between2sigma_left,

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -19,6 +19,7 @@
         type Contributor,
         type UserDisplayData,
     } from "$lib/metrics";
+    import { info } from "@tauri-apps/plugin-log";
 
     let {
         contributors,
@@ -51,6 +52,25 @@
     let ref_point_values: number[] = $state([]);
     let ref_points: { label: string; value: number }[] = $state([]);
     let resize_handler: () => void;
+
+    function profile_txt_colour(colour_str: string): string {
+        const r = parseInt(colour_str.substring(1, 3), 16);
+        const g = parseInt(colour_str.substring(3, 5), 16);
+        const b = parseInt(colour_str.substring(5, 7), 16);
+
+        const srgb: number[] = [r / 255, g / 255, b / 255];
+
+        const x: number[] = srgb.map((c) => {
+            if (c <= 0.04045) {
+                return c / 12.92;
+            } else {
+                return Math.pow((c + 0.055) / 1.055, 2.4);
+            }
+        });
+
+        const L: number = 0.2126 * x[0] + 0.7152 * x[1] + 0.0722 * x[2];
+        return L > 0.179 ? "#000" : "#fff";
+    }
 
     $effect(() => {
         switch (metric) {
@@ -397,6 +417,8 @@
                     );
                 }
 
+                info(`${person.username}: ${person.profile_colour}`);
+
                 const is_rightmost = person.data_to_display === x_max;
                 return {
                     type: "group",
@@ -416,7 +438,9 @@
                             textContent: {
                                 style: {
                                     text: person.initials,
-                                    fill: "#000",
+                                    fill: profile_txt_colour(
+                                        person.profile_colour
+                                    ),
                                     font: 'bold 16px "DM Sans ExtraBold", sans-serif',
                                 },
                                 z: idx + 4,

--- a/src/lib/components/overview-page/Graph.svelte
+++ b/src/lib/components/overview-page/Graph.svelte
@@ -369,6 +369,7 @@
                 ],
             };
         });
+
         const user_graphics = processed_people.map(
             (person: any, idx: number) => {
                 const [baseX, y] = chart.convertToPixel({ gridIndex: 0 }, [
@@ -410,7 +411,7 @@
                             },
                             x,
                             y,
-                            z: 3,
+                            z: idx + 3,
                             silent: false,
                             textContent: {
                                 style: {
@@ -418,7 +419,7 @@
                                     fill: "#000",
                                     font: 'bold 16px "DM Sans ExtraBold", sans-serif',
                                 },
-                                z: 4,
+                                z: idx + 4,
                             },
                             textConfig: {
                                 position: "inside",
@@ -441,7 +442,7 @@
                                       },
                                       x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
                                       y: y - 15,
-                                      z: 2,
+                                      z: idx + 2,
                                   },
 
                                   {
@@ -458,7 +459,7 @@
                                       },
                                       x: is_rightmost ? x - 40 : x + 40, // Left for rightmost, right otherwise
                                       y: y + 5,
-                                      z: 2,
+                                      z: idx + 2,
                                   },
                               ]
                             : []),

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -8,13 +8,19 @@ export type Contacts =
     | { Email: string }
     | { [key: string]: string };
 
+export type Colour = Readonly<{
+    r: number;
+    g: number;
+    b: number;
+}>;
+
 export type Contributor = Readonly<{
     username: string;
     contacts: Contacts;
     total_commits: number;
     additions: number;
     deletions: number;
-    profile_bg_colour: string;
+    profile_colour: string;
     username_initials: string;
     ai_summary: string;
 }>;
@@ -22,7 +28,7 @@ export type Contributor = Readonly<{
 export type UserDisplayData = Readonly<{
     username: string;
     initials: string;
-    profile_bg_colour: string;
+    profile_colour: string;
     data_to_display: number;
     offsetIndex?: number;
 }>;
@@ -465,7 +471,7 @@ export function get_users_total_commits(
         userTotalCommits.push({
             username: user.username,
             initials: user.username_initials,
-            profile_bg_colour: user.profile_bg_colour,
+            profile_colour: user.profile_colour,
             data_to_display: user.total_commits,
         });
     });
@@ -504,7 +510,7 @@ export function get_users_avg_commit_size(
         userAvgCommitSize.push({
             username: user.username,
             initials: user.username_initials,
-            profile_bg_colour: user.profile_bg_colour,
+            profile_colour: user.profile_colour,
             data_to_display: Number(
                 (
                     get_user_total_lines_of_code(user) / user.total_commits
@@ -550,7 +556,7 @@ export function get_users_absolute_diff(
         userAbsoluteDiff.push({
             username: user.username,
             initials: user.username_initials,
-            profile_bg_colour: user.profile_bg_colour,
+            profile_colour: user.profile_colour,
             data_to_display: get_user_absolute_diff(user),
         });
     });

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -14,14 +14,15 @@ export type Contributor = Readonly<{
     total_commits: number;
     additions: number;
     deletions: number;
-    bitmap_hash: string; // tmp use to store gravatar login
-    bitmap: string; // tmp use to store gravatar url
+    profile_bg_colour: string;
+    username_initials: string;
     ai_summary: string;
 }>;
 
 export type UserDisplayData = Readonly<{
     username: string;
-    image: string;
+    initials: string;
+    profile_bg_colour: string;
     data_to_display: number;
     offsetIndex?: number;
 }>;
@@ -462,8 +463,9 @@ export function get_users_total_commits(
     let userTotalCommits: UserDisplayData[] = [];
     users.forEach((user) => {
         userTotalCommits.push({
-            username: user.bitmap_hash,
-            image: user.bitmap,
+            username: user.username,
+            initials: user.username_initials,
+            profile_bg_colour: user.profile_bg_colour,
             data_to_display: user.total_commits,
         });
     });
@@ -500,8 +502,9 @@ export function get_users_avg_commit_size(
     let userAvgCommitSize: UserDisplayData[] = [];
     users.forEach((user) => {
         userAvgCommitSize.push({
-            username: user.bitmap_hash,
-            image: user.bitmap,
+            username: user.username,
+            initials: user.username_initials,
+            profile_bg_colour: user.profile_bg_colour,
             data_to_display: Number(
                 (
                     get_user_total_lines_of_code(user) / user.total_commits
@@ -545,8 +548,9 @@ export function get_users_absolute_diff(
     let userAbsoluteDiff: UserDisplayData[] = [];
     users.forEach((user) => {
         userAbsoluteDiff.push({
-            username: user.bitmap_hash,
-            image: user.bitmap,
+            username: user.username,
+            initials: user.username_initials,
+            profile_bg_colour: user.profile_bg_colour,
             data_to_display: get_user_absolute_diff(user),
         });
     });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,7 +27,7 @@
         try {
             let data = await invoke<ManifestSchema>("read_manifest");
             manifest.set(data);
-            info("page " + data);
+            info("page " + JSON.stringify(data));
         } catch (e: any) {
             let err = typeof e === "string" ? e : (e?.message ?? String(e));
             error("read_manifest failed: " + err);


### PR DESCRIPTION
## Changes

Profile icons were previously sourced from gravatars API which would fetch the contributors github profile icon or generate one from the provided username. Instead, the application now uses a simple hash of a contributors username to extract a 6-digit hex value to use as a background colour for the profile icons. The colour is pair with an initialism of the username (up-to the first 3 letters) to create unique profile icons for each contributor.
